### PR TITLE
#96 Convert `#block__popper` to a button with title attribute.

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -424,7 +424,10 @@ a.header-link:hover {
   top: $headerHeight + 40px;
   left: 0;
   right: 0;
+  width: 100%;
   height: $blockHeight - 20px;
+  outline: 0;
+  border: 0;
   background: $offWhite;
 }
 

--- a/public/js/components/renderer.js
+++ b/public/js/components/renderer.js
@@ -132,8 +132,8 @@ var Renderer = React.createClass({
       iframe = ( <div><iframe id='block__iframe'></iframe></div> )
     }
     return (
-      <div className={'renderer'}>
-        <div id='block__popper'></div>
+      <div className='renderer'>
+        <button id='block__popper' title='Toggle preview'></button>
         {iframe}
       </div>
     )


### PR DESCRIPTION
Fixes #96 

I tried to make pretty tooltip like on the Login link, but it would require some more html manipulation (tooltip was attached visually to the top-center of the button element, which was not ideal), so i added standard html attribute.

Changing placement to top left didnt work. Unless i did something wrong trying to use `data-place="top left"` / `"topLeft"`

In future i think there is a possibility to add a `span` inside `<button>` tag and attach tooltip to that element. 