### PR TITLE
Update codemirror

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -17,6 +17,8 @@ html {
 
 body {
   font-family: "Open Sans", Helvetica, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -webkit-text-stroke: 1px rgba(0,0,0,0.1);
   margin: 0 auto;
   position: relative;
   tab-size: 2;

--- a/views/base.handlebars
+++ b/views/base.handlebars
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<head>  
+<head>
   <meta charset="utf-8">
   <title>Building Bl.ocks</title>
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700,400italic|Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
 
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/codemirror.min.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/theme/mdn-like.min.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/dialog/dialog.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/codemirror.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/theme/mdn-like.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/dialog/dialog.min.css">
 
   <link rel="stylesheet" href="/inlet/inlet.css" type="text/css" media="screen"  title="no title" charset="utf-8">
 
@@ -26,18 +26,18 @@
   <div id='app'></div>
 
   <!-- SCRIPTS -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/codemirror.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/mode/xml/xml.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/mode/javascript/javascript.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/mode/coffeescript/coffeescript.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/mode/css/css.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/mode/htmlmixed/htmlmixed.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/dialog/dialog.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/search/searchcursor.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/search/search.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/edit/matchbrackets.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/edit/closebrackets.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.9.0/addon/comment/comment.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/codemirror.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/mode/xml/xml.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/mode/javascript/javascript.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/mode/coffeescript/coffeescript.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/mode/css/css.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/mode/htmlmixed/htmlmixed.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/dialog/dialog.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/search/searchcursor.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/search/search.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/edit/matchbrackets.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/edit/closebrackets.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.16.0/addon/comment/comment.min.js"></script>
 
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/marked/0.3.5/marked.min.js"></script>


### PR DESCRIPTION
I updated codemirror to current minor version (couple KBs less to download and hopefully some good fixes.

Release notes: http://codemirror.net/doc/releases.html

Full list of changes for anyone bored: https://github.com/codemirror/CodeMirror/compare/5.9.0...5.16.0


I also added small trick that should improve a little bit readability and overall experience with text on webkit based browsers @ OSX.

Before:
![image](https://cloud.githubusercontent.com/assets/546845/16873411/4c2d48be-4a93-11e6-9c3f-d0d143f6fb65.png)
![image](https://cloud.githubusercontent.com/assets/546845/16873415/511628a0-4a93-11e6-9a06-c22d48288370.png)


After:
![image](https://cloud.githubusercontent.com/assets/546845/16873417/56404fcc-4a93-11e6-9116-ffbaa9e4c1ef.png)
![image](https://cloud.githubusercontent.com/assets/546845/16873422/5be9725a-4a93-11e6-8ed1-9e2b5ed3a995.png)

Change is subtle, but text is visible softer if you open full version of the image.