### PR TITLE
Rename "building bl.ocks" to "bl.ock builder" across the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bl.ock Builder
 
-[![Join the chat at https://gitter.im/enjalot/blockbuilder](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/enjalot/building-blocks?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
+[![Join the chat at https://gitter.im/enjalot/blockbuilder](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/enjalot/blockbuilder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
 Create, fork and edit d3.js code snippets for use with bl.ocks.org right in the browser, no terminal required.
 
 # Usage

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enjalot/building-blocks.git"
+    "url": "git+https://github.com/enjalot/blockbuilder.git"
   },
   "keywords": [
     "d3.js",
@@ -22,9 +22,9 @@
   "author": "Ian Johnson",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/enjalot/building-blocks/issues"
+    "url": "https://github.com/enjalot/blockbuilder/issues"
   },
-  "homepage": "https://github.com/enjalot/building-blocks#readme",
+  "homepage": "https://github.com/enjalot/blockbuilder#readme",
   "dependencies": {
     "babel-core": "^6.4.0",
     "babel-loader": "^6.2.1",

--- a/public/js/components/about.js
+++ b/public/js/components/about.js
@@ -83,7 +83,7 @@ var About = React.createClass({
 
         <h1>About</h1>
         <p>
-          Getting started with Building Blocks? read about <a href='https://github.com/enjalot/building-blocks/wiki/How-it-works'>how this site works!</a>
+          Getting started with Bl.ock Builder? read about <a href='https://github.com/enjalot/blockbuilder/wiki/How-it-works'>how this site works!</a>
           <br></br>
           Watch the short video below for an overview of the functionality:
         </p>
@@ -99,10 +99,10 @@ var About = React.createClass({
 
         <p>
           Reach out to <a href='http://twitter.com/enjalot'>enjalot</a> for feedback & ideas.
-          Please <a href='https://github.com/enjalot/building-blocks/issues'>add an issue</a> on GitHub if you find a bug!
+          Please <a href='https://github.com/enjalot/blockbuilder/issues'>add an issue</a> on GitHub if you find a bug!
         </p>
 
-        <p> This project is open source, so all the code is <a href='https://github.com/enjalot/building-blocks'>on GitHub</a>!
+        <p> This project is open source, so all the code is <a href='https://github.com/enjalot/blockbuilder'>on GitHub</a>!
           See how the project came about <a href='https://www.kickstarter.com/projects/1058500513/building-blocks-0'>on kickstarter</a>.
         </p>
 
@@ -135,7 +135,7 @@ var About = React.createClass({
         <p>
           Bl.ocks chosen by the "Building Block" level <a href='https://www.kickstarter.com/projects/1058500513/building-blocks-0'>kickstarter backers</a>.
           <br/>
-          These bl.ocks represent people's favorite examples, so try playing with them in Block Builder.
+          These bl.ocks represent people's favorite examples, so try playing with them in Bl.ock Builder.
         </p>
 
         <div className='gallery'>
@@ -149,7 +149,7 @@ var About = React.createClass({
           <p>
             A special thanks to some friends who supported this project in several ways: <a href='http://twitter.com/enoex'>Erik Hazzard</a>, <a href='http://twitter.com/vicapow'>Victor Powell</a> and <a href='http://twitter.com/zanstrong'>Zan Armstrong</a>.
           </p>
-          <p>Of course thanks to everyone who <a href='https://github.com/enjalot/building-blocks/graphs/contributors'>contributed code</a>.</p>
+          <p>Of course thanks to everyone who <a href='https://github.com/enjalot/blockbuilder/graphs/contributors'>contributed code</a>.</p>
 
           <p>Much love to <a href='http://bl.ocks.org/enjalot/476c804335f77198447e'>everyone who backed</a>!</p>
         </div>

--- a/public/js/components/gallery.js
+++ b/public/js/components/gallery.js
@@ -75,9 +75,9 @@ var Gallery = React.createClass({
           </div>
         </div>
         <h1>Gallery</h1>
-        <p> Bl.ocks chosen by the "Building Block" level <a href='https://www.kickstarter.com/projects/1058500513/building-blocks-0'>kickstarter backers</a>.
+        <p>Bl.ocks chosen by the "Bl.ock Builder" level <a href='https://www.kickstarter.com/projects/1058500513/building-blocks-0'>kickstarter backers</a>.
         <br/>
-        These bl.ocks represent people's favorite examples, so try playing with them in Block Builder.
+        These bl.ocks represent people's favorite examples, so try playing with them in Bl.ock Builder.
         </p>
         <div className='gallery columns-two'>
           {thumbs}

--- a/public/js/components/header__nav-gist.js
+++ b/public/js/components/header__nav-gist.js
@@ -14,7 +14,7 @@ var GistNav = React.createClass({
   componentDidUpdate: function componentDidUpdate() {
     var gist = this.props.gist;
     if (gist && gist.description) {
-      d3.select("title").node().innerHTML = gist.description + " - Building Bl.ocks";
+      d3.select("title").node().innerHTML = gist.description + " - Bl.ock Builder";
     }
   },
   handleDescriptionChange: function handleDescriptionChange() {

--- a/public/js/components/home.js
+++ b/public/js/components/home.js
@@ -205,12 +205,12 @@ var Home = React.createClass({
             <div onClick={this.getStarted} id='getstarted' className='getstarted'>start coding</div>
           </div>
           <div id='tutorial__content'>
-            <h1>Building Blocks</h1>
+            <h1>Bl.ock Builder</h1>
             <p className='subhead'>
               Quickly create, edit and fork d3.js examples
             </p>
             <p className='tut'>
-              Are you learning d3 or trying out new ideas? Block builder is an in-browser code editor built for creating and sharing d3.js examples.
+              Are you learning d3 or trying out new ideas? Bl.ock Builder is an in-browser code editor built for creating and sharing d3.js examples.
               Check out this short video for an overview of how it works!
             </p>
             <iframe src='https://player.vimeo.com/video/138783462' width='711' height='400' frameBorder='0' webkitAllowFullScreen mozAllowFullScreen allowFullScreen></iframe>
@@ -218,7 +218,7 @@ var Home = React.createClass({
             <h2>Create and Edit</h2>
             <p className='tut'>
               If you login with GitHub, all of your examples will save to GitHub gists associated with your account.
-              Everything is powered by URL, so when you create a new block in Block Builder your URL will change to something like
+              Everything is powered by URL, so when you create a new block in Bl.ock Builder your URL will change to something like
             </p>
             <pre className='url'>
               <a target='_blank' href='http://blockbuilder.org/enjalot/64dbd9b7b740ba44462f'>http://<span className='domain'>blockbuilder.org</span>/enjalot/64dbd9b7b740ba44462f</a>
@@ -247,14 +247,14 @@ var Home = React.createClass({
             </p>
             <h3>Bookmarklet</h3>
             <p className='tut'>
-              It can get annoying to edit the URL all the time. If you drag this link: <a href='javascript:(function()%7Bvar current %3D window.location %2B ""%3Bvar newUrl %3D current.replace("http%3A%2F%2Fbl.ocks.org"%2C "http%3A%2F%2Fblockbuilder.org")%3BnewUrl %3D newUrl.replace("https%3A%2F%2Fgist.github.com"%2C "http%3A%2F%2Fblockbuilder.org")%3Bwindow.location %3D newUrl%7D)()'>Block Builder</a> into
+              It can get annoying to edit the URL all the time. If you drag this link: <a href='javascript:(function()%7Bvar current %3D window.location %2B ""%3Bvar newUrl %3D current.replace("http%3A%2F%2Fbl.ocks.org"%2C "http%3A%2F%2Fblockbuilder.org")%3BnewUrl %3D newUrl.replace("https%3A%2F%2Fgist.github.com"%2C "http%3A%2F%2Fblockbuilder.org")%3Bwindow.location %3D newUrl%7D)()'>Bl.ock Builder</a> into
               your bookmark bar and click it while on a gist or block it will take you to blockbuilder.org!
             </p>
 
             <h3>How it works</h3>
             <p className='tut'>
-              Read more here about <a target='_blank' href='https://github.com/enjalot/building-blocks/wiki/How-it-works'>how Block Builder works</a>.
-              It is <a target='_blank' href='https://github.com/enjalot/building-blocks'>open source software</a>, so checkout the <a href='https://github.com/enjalot/building-blocks/issues'>issues</a> or catch us in <a target='_blank' href='https://gitter.im/enjalot/building-blocks'>our chat room</a>.
+              Read more here about <a target='_blank' href='https://github.com/enjalot/blockbuilder/wiki/How-it-works'>how Bl.ock Builder works</a>.
+              It is <a target='_blank' href='https://github.com/enjalot/blockbuilder'>open source software</a>, so checkout the <a href='https://github.com/enjalot/blockbuilder/issues'>issues</a> or catch us in <a target='_blank' href='https://gitter.im/enjalot/blockbuilder'>our chat room</a>.
             </p>
             <h3>Try it out</h3>
             <p className='tut'>

--- a/server.js
+++ b/server.js
@@ -385,7 +385,7 @@ function saveGist(gist, method, token, cb) {
     gist = modifyGistForHistory(parsed);
   }
   var headers = {
-    'User-Agent': 'Building Bl.ocks',
+    'User-Agent': 'Bl.ock Builder',
     'content-type': 'application/json',
     'accept': 'application/json'
   };
@@ -451,7 +451,7 @@ function getGist(gistId, cb) {
       'client_secret': nconf.get('github:secret')
     },
     headers: {
-      'User-Agent': 'Building Bl.ocks'
+      'User-Agent': 'Bl.ock Builder'
     }
   };
   request.get(options, cb);
@@ -461,5 +461,5 @@ var server = app.listen(nconf.get('app:port'), function() {
   var host = server.address().address;
   var port = server.address().port;
 
-  console.log('Building Bl.ocks listening at http://%s:%s', host, port);
+  console.log('Bl.ock Builder listening at http://%s:%s', host, port);
 });

--- a/views/base.handlebars
+++ b/views/base.handlebars
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8">
-  <title>Building Bl.ocks</title>
+  <title>Bl.ock Builder</title>
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700,400italic|Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Hi,

I was confused why sometimes on the page (for example in the title) i can legacy name and sometimes block builder and sometimes bl.ock builder, so i unified it using git repo name and domain name as an source of truth.

I didnt change anything in deploy scripts/npm naming/urls to images because i was scared :)