### PR TITLE
if host is ::, replace with localhost so that server.js logs out a working link …

### DIFF
--- a/server.js
+++ b/server.js
@@ -459,6 +459,7 @@ function getGist(gistId, cb) {
 
 var server = app.listen(nconf.get('app:port'), function() {
   var host = server.address().address;
+  if (host === '::') host = 'localhost';
   var port = server.address().port;
 
   console.log('Bl.ock Builder listening at http://%s:%s', host, port);


### PR DESCRIPTION
…for local development.  fixes #178 

#### before

<img width="1420" alt="screen shot 2016-09-24 at 11 36 00 am" src="https://cloud.githubusercontent.com/assets/2119400/18810473/fdd8f6d6-824b-11e6-9d05-f1a7417088ce.png">

#### after

<img width="1416" alt="screen shot 2016-09-24 at 11 41 16 am" src="https://cloud.githubusercontent.com/assets/2119400/18810474/0612be2c-824c-11e6-8dec-cda4c2302cc3.png">

