### PR TITLE
show more acccurate ipv6 local server address http://[::]:8889

### DIFF
--- a/server.js
+++ b/server.js
@@ -459,7 +459,7 @@ function getGist(gistId, cb) {
 
 var server = app.listen(nconf.get('app:port'), function() {
   var host = server.address().address;
-  if (host === '::') host = 'localhost';
+  if (host === '::') host = '[::]';
   var port = server.address().port;
 
   console.log('Bl.ock Builder listening at http://%s:%s', host, port);


### PR DESCRIPTION
thanks to @leitzler @pavelloz for the comments over on #179 

this should be an improvement over the change from #179 

`http://[::]:8889`

![screen shot 2016-09-28 at 4 43 41 pm](https://cloud.githubusercontent.com/assets/2119400/18936300/152c29b4-859b-11e6-9089-defe998e9a8e.png)

![screen shot 2016-09-28 at 4 46 48 pm](https://cloud.githubusercontent.com/assets/2119400/18936350/7af01abc-859b-11e6-9c1b-b680444768f4.png)
