### PR TITLE
style CodeMirror-matchingbracket to opacity: 0.4 

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -191,6 +191,10 @@ a.header-link:hover {
   font-size: 18px;
 }
 
+.CodeMirror-matchingbracket {
+  opacity: 0.4;
+}
+
 #auth {
   float: right;
   margin: 0 5px;


### PR DESCRIPTION
so that cursor is not occluded

fix #176 

![better-matching-bracket-0 4](https://cloud.githubusercontent.com/assets/2119400/25966238/4c032fc8-363f-11e7-8b69-f736315c708c.gif)
