### PR TITLE
gracefully handle a gist that is missing an index.html fix #140

### DIFF
--- a/public/js/stores/gists.js
+++ b/public/js/stores/gists.js
@@ -67,7 +67,7 @@ var GistsStore = Reflux.createStore({
     // making another fetch request if they look at the same gistId
     this.gistsById[data.gistId] = data.response;
 
-    var index = data.response.files["index.html"];
+    var index = data.response.files["index.html"] || { content: "" };
     index.content = stripRelativeBlock(index.content);
 
     this.trigger({


### PR DESCRIPTION
blockbuilder will no longer hang if a gist is missing an `index.html` file

fixes #140 

![screen shot 2017-05-11 at 1 27 26 pm](https://cloud.githubusercontent.com/assets/2119400/25970503/c7305636-364d-11e7-89fe-0296b74d826e.png)
