### PR TITLE
Fix for text styling in default "fresh block"

### DIFF
--- a/public/js/components/home.js
+++ b/public/js/components/home.js
@@ -48,8 +48,8 @@ var defaultIndexContent = `<!DOCTYPE html>
       .text("Edit the code below to change me!")
       .attr("y", 200)
       .attr("x", 120)
-      .style("font-size", 36)
-      .style("font-family", "monospace")
+      .attr("font-size", 36)
+      .attr("font-family", "monospace")
 
   </script>
 </body>


### PR DESCRIPTION
Fix for #204 
Uses svg.attr instead of svg.style so that it works in Firefox and Google Chrome.
Sorry for the messy commits... I'm not very skilled in git...