### PR TITLE
"view bl.ock" now links to the specific revision of the latest gist

### DIFF
--- a/public/js/components/block.js
+++ b/public/js/components/block.js
@@ -201,7 +201,9 @@ var Block = React.createClass({
       this.setState({ failed: true, failMessage: failMessage });
     } else if (data.type === 'save:completed') {
       // console.log("SAVED");
-      this.setState({ saving: false });
+      var gist = this.state.gistData;
+      gist.history = data.gist.history;
+      this.setState({ saving: false, gistData: gist });
       window.onbeforeunload = null;
     } else if (data.type === 'save:failed') {
       // console.log("SAVE FAILED :(");

--- a/public/js/components/header__nav-gist.js
+++ b/public/js/components/header__nav-gist.js
@@ -39,6 +39,8 @@ var GistNav = React.createClass({
     var gistUrl = "https://gist.github.com/" + userName + '/' + this.props.params.gistId;
     var blocksUrl = "http://bl.ocks.org/" + userName + '/' + this.props.params.gistId;
 
+    if (gist && gist.history) blocksUrl += '/' + gist.history[0].version;
+
     if (!gist) return (<div id='block__nav'></div>);
     if (this.props.page === "home") return (
       <div id='block__nav'>


### PR DESCRIPTION
By specifying a revision, users can immediately see changes in bl.ocks.org after a gist is updated or uploaded. Without specifying a revision, bl.ocks.org caches a block for 5 minutes, and the browser caches it for perhaps longer.

For more info on caching, see https://bost.ocks.org/mike/block/#update