### PR TITLE
correctly identify line number when displaying error

### DIFF
--- a/public/js/components/editor__html.js
+++ b/public/js/components/editor__html.js
@@ -94,7 +94,7 @@ var EditorHTML = React.createClass({
             var message = evt.data.message.toString();
             var marker = document.createElement("div");
             marker.style.color = "#dd737a";
-            this.codeMirror.setGutterMarker(evt.data.lineNumber - 1, "errors", marker);
+            this.codeMirror.setGutterMarker(evt.data.lineNumber, "errors", marker);
             d3.select(".CodeMirror-gutters").style("border-left", "6px solid rgba(221, 115, 122, 1)");
             var component = ReactDOM.render(tooltip, marker);
             component.setMessage(message);


### PR DESCRIPTION
As @curran noted, the client currently represents a line fail icon next to `lineNumberWithError` -1:

![c8c0bf2c-3545-11e6-9691-893a44e70536](https://user-images.githubusercontent.com/4801116/31054778-2437a3d4-a688-11e7-96a6-ad021e0c0e65.png)

This PR corrects this behavior so faulty line numbers are correctly identified:
![updated-line-number](https://user-images.githubusercontent.com/4801116/31054789-59e6ab1a-a688-11e7-8af2-7029a0366334.png)

closes #142 

