### PR TITLE
[developer experience] Add docker-compose file for simpler local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.4'
+services:
+
+  # Docker service, because mongo_client can't find the right redis host
+  # Instead, run node server.js on your local machine and it should be fine.
+  # web:
+  #   image: node:alpine
+  #   volumes:
+  #     - ./:/app
+  #   working_dir: /app
+  #   depends_on:
+  #     - mongo
+  #     - redis
+  #   environment:
+  #     NODE_ENV: development
+  #   ports:
+  #     - 8889:8889
+  #   command: node server.js
+
+  # Backend Services
+  # Ports are defined in ./resources.json
+  redis:
+    image: "redis:alpine"
+    ports:
+      - 6379:6379
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+
+  # TODO: Add elasticsearch 2.3.4 for blockbuilder-search-index


### PR DESCRIPTION
This PR adds a docker-compose script that can run Redis and MongoDb inside a docker container, for more convenient local development.

This is my first pass at https://github.com/enjalot/blockbuilder-search/issues/74 . 

## How to Test

- Assuming you have homebrew, install `docker-compose` and `docker`.

```bash
   brew cask install docker
```

Then, clone `blockbuilder` and perform the basic setup.

```bash
# Terminal
yarn
yarn buildWatch

# Terminal 2
docker-compose up 
# When done, remove networks with with docker-compose down

# Terminal 3
node server.js
```

The application will be available on `localhost:8889`!

## Process Notes

- I tried setting up a custom bridge network using the [docker docs](https://docs.docker.com/compose/networking/), passing in a custom `redis.conf` to bind redis to all ports instead of just `localhost`, and linking the services using the `link` key in docker-compose, with no luck - the mongo_client code is unable to bind to redis. I'm not sure why yet. I do know redis was running correctly because I could still connect to it via `redis-commander`.

- Happily, this seems to work just fine running the node server on your laptop directly, so this docker compose setup already is preferable to me manually spinning up mongo and redis.

- I realized in working this that I suspect that running all this on a local machine is unnecessary if someone wants to just make frontend changes, so I am going to try to come up with an alternate workflow specifically for hacking on the `blockbuilder-search` page.