### PR TITLE
bump magic sandbox to v1.5.0 to get https issue fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express-session": "^1.13.0",
     "install": "^0.4.1",
     "jsdom": "^12.0.0",
-    "magic-sandbox": "^1.1.0",
+    "magic-sandbox": "^1.5.0",
     "mongodb": "^2.1.3",
     "nconf": "^0.8.2",
     "node-sass": "^4.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,10 +4393,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-magic-sandbox@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/magic-sandbox/-/magic-sandbox-1.2.0.tgz#eced90c30deae66f6be13cf2e0d73a305390262c"
-  integrity sha512-1Vvlvhkma3uec9XoOjN/OzAlqDZYsnZCEtoCjHrNT/ANMIzZUe68Dh2XSGgaXgtVOX2dIW41YxdXTQB0Y6BDJw==
+magic-sandbox@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/magic-sandbox/-/magic-sandbox-1.5.0.tgz#4363ae1228043ca583cf16e68cb83433ed7a9785"
+  integrity sha512-+5RBThSM2UsPCWfaOkVb/5m0Ew03HYH/h6Km6QnMvla7bcKFAxRVYsFggpRgGtOfQCUDRz03K1hIurk5+QDy6g==
 
 magic-string@^0.22.4:
   version "0.22.5"


### PR DESCRIPTION
bump magic sandbox to v1.5.0 to get https issue fix

fix #241 

# testing done

## before, left
example block that is broken on current prod https://blockbuilder.org/micahstubbs/842e41b2ac0ff702a0a04dc6e48dca92

## after, right
same example block, working on local frontend on this branch
http://localhost:8889/micahstubbs/842e41b2ac0ff702a0a04dc6e48dca92

![Screen Shot 2019-08-10 at 4 21 34 PM](https://user-images.githubusercontent.com/2119400/62827758-09286000-bb8b-11e9-9c70-27b090014d76.png)
